### PR TITLE
Make option for announcement available for profiles

### DIFF
--- a/addon/globalPlugins/clipspeak/__init__.py
+++ b/addon/globalPlugins/clipspeak/__init__.py
@@ -27,7 +27,7 @@ else:
 
 from . import clipboard_monitor
 # For update process
-from . update import *
+from .update import *
 import addonHandler
 addonHandler.initTranslation()
 
@@ -52,31 +52,6 @@ cm_undo=4
 cm_redo=5
 
 # Defining variables on NVDA.INI
-def initConfiguration():
-	global announcement
-	try:
-		value = config.conf[ourAddon.manifest["name"]]["announce"]
-	except KeyError:
-		config.conf[ourAddon.manifest["name"]] = {}
-		config.conf[ourAddon.manifest["name"]]["announce"] = "boolean(default=True)"
-		announcement = getConfig("announce")
-	else:
-		value = config.conf[ourAddon.manifest["name"]]["announce"]
-		announcement = True if value == "True" else False
-
-# Reading value of variable in NVDA.ini
-def getConfig(key):
-	value = config.conf[ourAddon.manifest["name"]][key]
-	return bool(value)
-
-# Saving value in NVDA.ini
-def setConfig(key, value):
-	try:
-		config.conf.profiles[0][ourAddon.manifest["name"]][key] = value
-	except:
-		config.conf[ourAddon.manifest["name"]][key] = value
-
-initConfiguration()
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):	
 	# Creating the constructor of the newly created GlobalPlugin class.
@@ -234,7 +209,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			word=_("item")
 
 		# Decide what will be announced...
-		if announcement == True:
+		if config.conf[ourAddon.name]["announce"]:
 			word = word1 = ""
 
 		# Validate and speak.
@@ -359,23 +334,15 @@ class ClipSpeakSettingsPanel(gui.SettingsPanel):
 
 		# Translators: Checkbox name in the configuration dialog
 		self.announceWnd = sHelper.addItem(wx.CheckBox(self, label=_("Announce only copy/cut/paste")))
-		self.announceWnd.Bind(wx.EVT_CHECKBOX, self.onChk2)
-		global announcement
-		self.announceWnd.Value = announcement
+		self.announceWnd.SetValue(config.conf[ourAddon.name]["announce"])
 
 		# Translators: Checkbox name in the configuration dialog
 		self.shouldUpdateChk = sHelper.addItem(wx.CheckBox(self, label=_("Check for updates at startup")))
-		self.shouldUpdateChk	.Bind(wx.EVT_CHECKBOX, self.onChk)
-		self.shouldUpdateChk	.Value = shouldUpdate
-
-	def onChk(self, event):
-		shouldUpdate = self.shouldUpdateChk.Value
-
-	def onChk2(self, event):
-		global announcement
-		announcement = self.announceWnd.Value
+		self.shouldUpdateChk.SetValue(config.conf[ourAddon.name]["isUpgrade"])
+		if config.conf.profiles[-1].name:
+			self.shouldUpdateChk.Disable()
 
 	def onSave (self):
-		setConfig("isUpgrade", self.shouldUpdateChk.Value)
-		setConfig("announce", self.announceWnd.Value)
-
+		config.conf[ourAddon.name]["announce"] = self.announceWnd.GetValue()
+		if not config.conf.profiles[-1].name:
+			config.conf[ourAddon.name]["isUpgrade"] = self.shouldUpdateChk.GetValue()

--- a/addon/globalPlugins/clipspeak/update.py
+++ b/addon/globalPlugins/clipspeak/update.py
@@ -36,31 +36,21 @@ import shutil
 addonHandler.initTranslation()
 
 def getOurAddon():
-	for addon in addonHandler.getAvailableAddons():
-		if str(os.path.dirname(__file__).split("\\")[-1:]).replace("[", "").replace("\'", "").replace("]", "") == addon.manifest['name']:
-			return addon
+	return addonHandler.getCodeAddon()
 
 ourAddon = getOurAddon()
 bundle = getOurAddon()
 
 def initConfiguration():
 	confspec = {
-		"isUpgrade": "boolean(default=False)",
+		"announce": "boolean(default=True)",
+		"isUpgrade": "boolean(default=False)"
 	}
-	config.conf.spec[ourAddon.manifest["name"]] = confspec
+	config.conf.spec[ourAddon.name] = confspec
 
-def getConfig(key):
-	value = config.conf[str(ourAddon.manifest["name"])][key]
-	return value
-
-def setConfig(key, value):
-	try:
-		config.conf.profiles[0][ourAddon.manifest["name"]][key] = value
-	except:
-		config.conf[ourAddon.manifest["name"]][key] = value
 
 initConfiguration()
-shouldUpdate = getConfig("isUpgrade")
+shouldUpdate = config.conf[ourAddon.name]["isUpgrade"]
 urlRepos = "https://api.github.com/repos/ruifontes/"+ourAddon.manifest["name"]+"/releases"
 urlName = ""
 urlN = ""


### PR DESCRIPTION
This PR adds ability to set the "Announce only copy/cut/paste" option for profiles. This is consistent with other settings of NVDA and maybe useful to know if we're copying an item or a file in Windows Explorer, but we don't know to listen the text copied in an editor, for example for privacy or other use cases.
Also, the setUpgrade option is just available for the normal configuration, since doesn't make sense for profiles (it's to be user at start), also consistent with NVDA. This checkbox will be disabled if the addon panel is opened when a profile is active, and wwill be available if we are in normal configuration. Also, this option will be saved just if we are in normal configuration.

### Notes
- Some functions not needed have been removed.
- - ourAddon.name is been used instead of ourAddon.manifest["name"], since name is a property of the Addon class.
- The updae tasks seems to produce issues: I have to use Narrator on my laptop when the add-on requests to be updated, but this happens also with the original add-on.
@ruifontes please test all this and review changes.