### PR TITLE
Fix false copy announcement in terminals and correct Spanish translat…

### DIFF
--- a/addon/Locale/es/LC_MESSAGES/nvda.po
+++ b/addon/Locale/es/LC_MESSAGES/nvda.po
@@ -39,10 +39,8 @@ msgstr "Copiar elemento seleccionado en el portapapeles, si es apropiado."
 
 #. Translators: Message to be announced during Keyboard Help
 #: addon\globalPlugins\clipspeak\__init__.py:132
-#, fuzzy
-#| msgid "Copy selected item to clipboard, if appropriate."
 msgid "Copy path of selected file to clipboard, if appropriate."
-msgstr "Copiar elemento seleccionado en el portapapeles, si es apropiado."
+msgstr "Copiar ruta del archivo seleccionado en el portapapeles, si es apropiado."
 
 #. Translators: Message to be announced during Keyboard Help
 #: addon\globalPlugins\clipspeak\__init__.py:153
@@ -67,12 +65,12 @@ msgstr "elemento"
 #. Translators: Message to speak when undoing.
 #: addon\globalPlugins\clipspeak\__init__.py:409
 msgid "Undo"
-msgstr "Desacer"
+msgstr "Deshacer"
 
 #. Translators: A message spoken when redoing a previously undone operation.
 #: addon\globalPlugins\clipspeak\__init__.py:413
 msgid "Redo"
-msgstr "Reacer"
+msgstr "Rehacer"
 
 #. Translators: A message to speak when cutting text or files/folders to the clipboard.
 #: addon\globalPlugins\clipspeak\__init__.py:418
@@ -96,7 +94,7 @@ msgstr "Copiar %s"
 #: addon\globalPlugins\clipspeak\__init__.py:459
 #, python-format
 msgid "Pasted %s"
-msgstr "Pegar %s"
+msgstr "Pegado %s"
 
 #. Translators: Title of the ClipSpeak settings dialog in the NVDA settings.
 #: addon\globalPlugins\clipspeak\__init__.py:468
@@ -110,15 +108,15 @@ msgstr "Anunciar solo cortar/copiar/pegar"
 
 #: addon\globalPlugins\clipspeak\clipboardMonitor.py:51
 msgid "file/folder "
-msgstr ""
+msgstr "archivo/carpeta "
 
 #: addon\globalPlugins\clipspeak\clipboardMonitor.py:55
 msgid "files/folders: "
-msgstr ""
+msgstr "archivos/carpetas: "
 
 #: addon\globalPlugins\clipspeak\clipboardMonitor.py:57
 msgid " files/folders"
-msgstr ""
+msgstr " archivos/carpetas"
 
 #. Add-on summary, usually the user visible name of the addon.
 #. Translators: Summary for this add-on

--- a/addon/globalPlugins/clipspeak/__init__.py
+++ b/addon/globalPlugins/clipspeak/__init__.py
@@ -253,6 +253,20 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if not focus:
 			cc_last_flag = cc_none
 			return cc_none
+		# Check for terminal/console windows - Ctrl+C means "interrupt process", not "copy"
+		if focus.windowClassName in ("ConsoleWindowClass", "PseudoConsoleWindow", "VirtualConsoleClass"):
+			cc_last_flag = cc_none
+			return cc_none
+		if hasattr(controlTypes, "ROLE_TERMINAL") and focus.role == controlTypes.ROLE_TERMINAL:
+			cc_last_flag = cc_none
+			return cc_none
+		# VS Code / xterm.js terminal: focused element is a hidden textarea (xterm-helper-textarea)
+		try:
+			if getattr(focus, 'IA2Attributes', {}).get('class') == 'xterm-helper-textarea':
+				cc_last_flag = cc_none
+				return cc_none
+		except Exception:
+			pass
 		# Examining focus object
 		# Retrieve the control's states and roles.
 		states=focus.states
@@ -309,7 +323,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				# Field seems to be editable.")
 				cc_last_flag = cc_text
 				return cc_text
-		elif focus.windowClassName == "RichEditD2DPT" or "Scintilla":
+		elif focus.windowClassName in ("RichEditD2DPT", "Scintilla"):
 			cc_last_flag = cc_text
 			return cc_text
 		elif focus.windowClassName == "_WwG":
@@ -338,12 +352,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		return True
 
 	def can_cut(self, cc_flag):
-		changed = self.dataInstance.clipboardHasChanged()
-		return changed
+		if cc_flag in (cc_file, cc_file1):
+			type, _ = self.dataInstance.validClipboardData()
+			return type == 1
+		return self.dataInstance.clipboardHasChanged()
 
 	def can_copy(self, cc_flag):
-		changed = self.dataInstance.clipboardHasChanged()
-		return changed
+		if cc_flag in (cc_file, cc_file1):
+			type, _ = self.dataInstance.validClipboardData()
+			return type == 1
+		return self.dataInstance.clipboardHasChanged()
 
 	def can_copyAsPath(self, cc_flag):
 		changed = self.dataInstance.clipboardHasChanged()
@@ -374,7 +392,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 					return True
 			elif controlTypes.STATE_READONLY in states:
 				return False
-			elif focus.windowClassName == "RichEditD2DPT" or "Scintilla":
+			elif focus.windowClassName in ("RichEditD2DPT", "Scintilla"):
 				return True
 			elif focus.windowClassName == "_WwG":
 				return True


### PR DESCRIPTION
…ions

- Detect terminal context in examine_focus() to prevent Ctrl+C from triggering a false 'copy' announcement:
  - ConsoleWindowClass, PseudoConsoleWindow, VirtualConsoleClass (cmd, PowerShell, Windows Terminal)
  - ROLE_TERMINAL (terminals NVDA identifies natively)
  - xterm-helper-textarea IA2 attribute (VS Code integrated terminal and other xterm.js-based terminals)
- Fix Spanish translations: empty msgstr fields, fuzzy entries, typos (Desacer→Deshacer, Reacer→Rehacer, Pegar→Pegado), and wrong translation for 'Copy path of selected file'